### PR TITLE
Add asynchronous API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,46 @@ try {
 }
 ```
 
+## Usage
+
+Using the low level asynchronous api:
+
+```php
+require_once __DIR__.'/vendor/autoload.php';
+
+use ApiAi\Client;
+use ApiAi\Model\Query;
+use ApiAi\Method\QueryApi;
+use GuzzleHttp\HandlerStack;
+use React\EventLoop\Factory;
+use WyriHaximus\React\GuzzlePsr7\HttpClientAdapter;
+
+$loop = Factory::create();
+$reactGuzzle = new \GuzzleHttp\Client([
+    'base_uri' => Client::API_BASE_URI . Client::DEFAULT_API_ENDPOINT,
+    'timeout' => Client::DEFAULT_TIMEOUT,
+    'connect_timeout' => Client::DEFAULT_TIMEOUT,
+    'handler' => HandlerStack::create(new HttpClientAdapter($loop))
+]);
+
+$client = new Client('bc0a6d712bba4b3c8063a9c7ff0fa4ea', new ApiAi\HttpClient\GuzzleHttpClient($reactGuzzle));
+$queryApi = new QueryApi($client);
+
+$queryApi->extractMeaningAsync('Hello', [
+    'sessionId' => '123456789',
+    'lang' => 'en'
+])->then(
+    function ($meaning) {
+        $response = new Query($meaning);
+    },
+    function ($error) {
+        echo $error;
+    }
+);
+
+$loop->run();
+```
+
 ## Dialog
 
 The `Dialog` class provides an easy way to use the `query` api and execute automatically the chaining steps :

--- a/src/HttpClient/GuzzleHttpClient.php
+++ b/src/HttpClient/GuzzleHttpClient.php
@@ -38,6 +38,29 @@ class GuzzleHttpClient implements HttpClient
      */
     public function send($method, $uri, $body = null, array $query = [], array $headers = [], array $options = [])
     {
+        $options = $this->prepareOptions($body, $query, $headers, $options);
+        return $this->guzzleClient->request($method, $uri, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sendAsync($method, $uri, $body = null, array $query = [], array $headers = [], array $options = [])
+    {
+        $options = $this->prepareOptions($body, $query, $headers, $options);
+        return $this->guzzleClient->requestAsync($method, $uri, $options);
+    }
+
+    /**
+     * @param mixed $body
+     * @param array $query
+     * @param array $headers
+     * @param array $options
+     *
+     * @return array
+     */
+    private function prepareOptions($body, array $query, array $headers, array $options)
+    {
         $options = array_merge($options, [
             RequestOptions::QUERY => $query,
             RequestOptions::HEADERS => $headers,
@@ -49,7 +72,6 @@ class GuzzleHttpClient implements HttpClient
             $options[RequestOptions::BODY] = $body;
         }
 
-        return $this->guzzleClient->request($method, $uri, $options);
+        return $options;
     }
-
 }

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -2,6 +2,7 @@
 
 namespace ApiAi\HttpClient;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -22,4 +23,16 @@ interface HttpClient
      * @return ResponseInterface
      */
     public function send($method, $uri, $body = null, array $query = [], array $headers = [], array $options = []);
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param mixed $body
+     * @param array $query
+     * @param array $headers
+     * @param array $options
+     *
+     * @return PromiseInterface
+     */
+    public function sendAsync($method, $uri, $body = null, array $query = [], array $headers = [], array $options = []);
 }

--- a/src/Method/QueryApi.php
+++ b/src/Method/QueryApi.php
@@ -4,6 +4,8 @@ namespace ApiAi\Method;
 
 use ApiAi\Client;
 use ApiAi\ResponseHandler;
+use GuzzleHttp\Promise\PromiseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Class QueryApi
@@ -47,4 +49,19 @@ class QueryApi
         return $this->decodeResponse($response);
     }
 
+    /**
+     * @param $query
+     * @param array $extraParams
+     *
+     * @return PromiseInterface
+     */
+    public function extractMeaningAsync($query, $extraParams = [])
+    {
+        $query = array_merge($extraParams, [
+            'lang' => $this->client->getApiLanguage(),
+            'query' => $query,
+        ]);
+
+        return $this->client->postAsync('query', $query)->then([$this, 'decodeResponse']);
+    }
 }


### PR DESCRIPTION
Includes usage example for [reactphp](https://github.com/reactphp/event-loop) event loop.

This PR is sadly BC-breaking because it adds method to existing interface.