### PR TITLE
Rename API.AI to their new name of Dialogflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Api.ai PHP sdk
+Dialogflow PHP sdk
 ==============
 
 [![version][packagist-version]][packagist-url]
@@ -8,10 +8,10 @@ Api.ai PHP sdk
 [packagist-version]: https://img.shields.io/packagist/v/iboldurev/api-ai-php.svg?style=flat
 [packagist-downloads]: https://img.shields.io/packagist/dm/iboldurev/api-ai-php.svg?style=flat
 
-This is an unofficial php sdk for [Api.ai][1] and it's still in progress...
+This is an unofficial php sdk for [Dialogflow][1] and it's still in progress...
 
 ```
-Api.ai: Build brand-unique, natural language interactions for bots, applications and devices.
+Dialogflow: Build brand-unique, natural language interactions for bots, applications and devices.
 ```
 
 ## Install:
@@ -44,7 +44,7 @@ try {
 }
 ```
 
-## Usage:   
+## Usage:
 
 Using the low level `Query`:
 
@@ -95,7 +95,7 @@ class MyActionMapping extends ActionMapping
     {
         echo $speech;
     }
-    
+
     /**
      * @inheritdoc
      */
@@ -107,7 +107,7 @@ class MyActionMapping extends ActionMapping
 
 ```
 
-And using it in the `Dialog` class. 
+And using it in the `Dialog` class.
 
 ```php
 require_once __DIR__.'/vendor/autoload.php';
@@ -122,10 +122,10 @@ try {
     $queryApi = new QueryApi($client);
     $actionMapping = new MyActionMapping();
     $dialog = new Dialog($queryApi, $actionMapping);
-    
+
     // Start dialog ..
     $dialog->create('1234567890', 'Привет', 'ru');
-    
+
 } catch (\Exception $error) {
     echo $error->getMessage();
 }
@@ -134,5 +134,5 @@ try {
 
 Some examples are describe in the [iboldurev/api-ai-php-example][2] repository.
 
-[1]: https://api.ai
+[1]: https://dialogflow.com
 [2]: https://github.com/iboldurev/api-ai-php-example

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "iboldurev/api-ai-php",
-  "description": "API.ai php sdk",
+  "description": "Dialogflow php sdk",
   "minimum-stability": "stable",
   "license": "MIT",
   "authors": [
@@ -11,9 +11,10 @@
     }
   ],
   "keywords": [
-    "api.ai",
-    "api.ai sdk",
-    "bot"
+    "Dialogflow",
+    "Dialogflow sdk",
+    "bot",
+    "API.AI"
   ],
   "autoload": {
     "psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,7 +17,7 @@ class Client
     /**
      * API Base url
      */
-    const API_BASE_URI = 'https://api.api.ai/';
+    const API_BASE_URI = 'https://api.dialogflow.com/';
 
     /**
      * API Version
@@ -50,7 +50,7 @@ class Client
     public static $allowedMethod = ['GET', 'POST'];
 
     /**
-     * @var string Api.ai token
+     * @var string Dialogflow token
      */
     private $accessToken;
 


### PR DESCRIPTION
This PR updates API.AI's name to Dialogflow, which is the new name for their service. I updated every reference to API.AI I could find, and included the new endpoint. 

Not sure if you're planning on renaming the repo or how you'd like to handle the name change in that regard, but this should be a good starting point :) 

All the best,

json