### PR TITLE
Fix/pass authorization headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ composer.lock
 *.sublime-workspace
 *.phar
 *.log
+
+.env

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ try {
 
     $query = $client->get('query', [
         'query' => 'Hello',
+        'sessionId' => '13371337'
     ]);
 
     $response = json_decode((string) $query->getBody(), true);

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,10 @@
+paths:
+    tests: tests
+    output: tests/_output
+    data: tests/_data
+    support: tests/_support
+    envs: tests/_envs
+actor_suffix: Tester
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,9 @@
   "require": {
     "php": ">=5.5.0",
     "guzzlehttp/guzzle": "^6.2"
+  },
+  "require-dev": {
+    "codeception/codeception": "^2.4",
+    "vlucas/phpdotenv": "^2.5"
   }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -101,10 +101,8 @@ class Client
      */
     private function defaultHttpClient()
     {
-        return new GuzzleHttpClient([
-            'headers' => [
-                'Authorization' => sprintf('Bearer %s', $this->accessToken),
-            ],
+        return new GuzzleHttpClient(null, [
+            'Authorization' => sprintf('Bearer %s', $this->accessToken),
         ]);
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -101,7 +101,11 @@ class Client
      */
     private function defaultHttpClient()
     {
-        return new GuzzleHttpClient();
+        return new GuzzleHttpClient([
+            'headers' => [
+                'Authorization' => sprintf('Bearer %s', $this->accessToken),
+            ],
+        ]);
     }
 
     /**

--- a/src/HttpClient/GuzzleHttpClient.php
+++ b/src/HttpClient/GuzzleHttpClient.php
@@ -24,12 +24,13 @@ class GuzzleHttpClient implements HttpClient
      *
      * @param ClientInterface|null $guzzleClient
      */
-    public function __construct(ClientInterface $guzzleClient = null)
+    public function __construct(ClientInterface $guzzleClient = null, $headers)
     {
         $this->guzzleClient = $guzzleClient ?: new GuzzleClient([
             'base_uri' => Client::API_BASE_URI . Client::DEFAULT_API_ENDPOINT,
             'timeout' => Client::DEFAULT_TIMEOUT,
             'connect_timeout' => Client::DEFAULT_TIMEOUT,
+            'headers' => $headers,
         ]);
     }
 

--- a/tests/_output/.gitignore
+++ b/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class AcceptanceTester extends \Codeception\Actor
+{
+    use _generated\AcceptanceTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class FunctionalTester extends \Codeception\Actor
+{
+    use _generated\FunctionalTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Acceptance extends \Codeception\Module
+{
+
+}

--- a/tests/_support/Helper/Functional.php
+++ b/tests/_support/Helper/Functional.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Functional extends \Codeception\Module
+{
+
+}

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -1,0 +1,10 @@
+<?php
+namespace Helper;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Unit extends \Codeception\Module
+{
+
+}

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/_generated/.gitignore
+++ b/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -1,0 +1,12 @@
+# Codeception Test Suite Configuration
+#
+# Suite for acceptance tests.
+# Perform tests in browser using the WebDriver or PhpBrowser.
+# If you need both WebDriver and PHPBrowser tests - create a separate suite.
+
+actor: AcceptanceTester
+modules:
+    enabled:
+        - PhpBrowser:
+            url: http://localhost/myapp
+        - \Helper\Acceptance

--- a/tests/functional.suite.yml
+++ b/tests/functional.suite.yml
@@ -1,0 +1,12 @@
+# Codeception Test Suite Configuration
+#
+# Suite for functional tests
+# Emulate web requests and make application process them
+# Include one of framework modules (Symfony2, Yii2, Laravel5) to use it
+# Remove this suite if you don't use frameworks
+
+actor: FunctionalTester
+modules:
+    enabled:
+        # add a framework module here
+        - \Helper\Functional

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,0 +1,11 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit or integration tests.
+
+actor: UnitTester
+modules:
+    enabled:
+        - Asserts
+        - \Helper\Unit
+    params:
+    - .env

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -1,0 +1,33 @@
+<?php
+use DialogFlow\Client;
+
+class QueryTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    
+    protected function _before()
+    {
+        // wish there was a better way to load .env's in tests...
+        $dotenv = new Dotenv\Dotenv(__DIR__ . '/../../');
+        $dotenv->load();
+        $this->client = new Client($_ENV['DIALOGFLOW_CLIENT_ACCESS_TOKEN']);
+    }
+
+    protected function _after()
+    {
+    }
+
+    // tests
+    public function testQueryDoesNotRaiseException()
+    {
+        $query = $this->client->get('query', [
+            'query' => 'Hello',
+            'sessionId' => '1',
+        ]);
+
+        $response = json_decode((string) $query->getBody(), true);
+    }
+}


### PR DESCRIPTION
This is a pretty major change and if you're against it I totally understand.

1. This passes the Dialogflow Client Access Token to the GuzzleHttpClient's constructor as a `headers` entry so it's available on all requests
2. This adds Codeception as a testing suite with a rudimentary test for testing the integration for a basic query
3. This bypasses the internal `Dialogflow\HttpClient\GuzzleHttpClient` and just instantiates one in the `DialogFlow\Client` instead. In a perfect world, instantiation would be in a Factory or through a simple container, but I don't like to complicate if it's not necessary.
4. Updates the README to include the missing `sessionId` that needs passed as an argument to the query

Let me know your thoughts, if it's too drastic of a change that's alright I'll just maintain my fork.